### PR TITLE
C++ namespaces \o/

### DIFF
--- a/src/clang.rs
+++ b/src/clang.rs
@@ -252,7 +252,7 @@ pub struct Type {
 impl Type {
     // common
     pub fn kind(&self) -> Enum_CXTypeKind {
-        return self.x.kind;
+        self.x.kind
     }
 
     pub fn declaration(&self) -> Cursor {
@@ -340,7 +340,7 @@ impl Type {
             for i in 0..num {
                 args.push(Type { x: clang_getArgType(self.x, i as c_uint) });
             }
-            return args;
+            args
         }
     }
 

--- a/src/clangll.rs
+++ b/src/clangll.rs
@@ -5,7 +5,6 @@
 #![allow(unused_attributes)]
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]
-#![allow(raw_pointer_derive)]
 
 pub type ptrdiff_t = ::libc::c_long;
 pub type size_t = ::libc::c_ulong;

--- a/src/gen.rs
+++ b/src/gen.rs
@@ -1712,6 +1712,7 @@ fn mk_ptrty(ctx: &mut GenCtx, base: &ast::Ty, is_const: bool) -> ast::Ty {
     }
 }
 
+#[allow(dead_code)]
 fn mk_refty(ctx: &mut GenCtx, base: &ast::Ty, is_const: bool) -> ast::Ty {
     let ty = ast::TyRptr(
         None,

--- a/src/gen.rs
+++ b/src/gen.rs
@@ -37,6 +37,39 @@ impl<'r> GenCtx<'r> {
             current_id = module.parent_id;
         }
 
+        // XXX This is done because we don't actually print the root module.
+        //
+        // We include a lot of top-level "use's" instead.
+        //
+        // It might be desirable something like:
+        //
+        // ```
+        // use __randomlygeneratednameforroot::*;
+        // mod __randomlygeneratednameforroot {
+        //   pub mod b {
+        //     pub type ty = i32;
+        //   }
+        //   pub mod a {
+        //     static C: __randomlygeneratednameforroot::b::ty;
+        //   }
+        // }
+        // ```
+        //
+        // Vs:
+        //
+        // ```
+        // pub mod b {
+        //   use a;
+        //   pub type ty = i32;
+        // }
+        //
+        // pub mod a {
+        //   use b;
+        //   static C: b::ty;
+        // }
+        // ```
+        //
+        // Or even switching via flag back and forth.
         ret.pop(); // The root isn't really here
         ret.reverse();
         ret

--- a/src/gen.rs
+++ b/src/gen.rs
@@ -453,14 +453,14 @@ fn mk_extern(ctx: &mut GenCtx, links: &[(String, LinkType)],
         items: items
     });
 
-    return P(ast::Item {
-              ident: ctx.ext_cx.ident_of(""),
-              attrs: attrs,
-              id: ast::DUMMY_NODE_ID,
-              node: ext,
-              vis: ast::Inherited,
-              span: ctx.span
-           });
+    P(ast::Item {
+        ident: ctx.ext_cx.ident_of(""),
+        attrs: attrs,
+        id: ast::DUMMY_NODE_ID,
+        node: ext,
+        vis: ast::Inherited,
+        span: ctx.span
+    })
 }
 
 fn mk_impl(ctx: &mut GenCtx, ty: P<ast::Ty>,
@@ -511,9 +511,9 @@ fn remove_redundant_decl(gs: Vec<Global>) -> Vec<Global> {
         }
     ).collect();
 
-    return gs.into_iter().filter(|g|
+    gs.into_iter().filter(|g|
         !typedefs.iter().any(|t| check_decl(g, t))
-    ).collect();
+    ).collect()
 }
 
 fn tag_dup_decl(gs: &[Global]) -> Vec<Global> {
@@ -648,17 +648,17 @@ fn ctypedef_to_rs(ctx: &mut GenCtx, name: String, comment: String, ty: &Type) ->
             empty_generics()
         );
 
-        return P(ast::Item {
-                  ident: ctx.ext_cx.ident_of(&rust_name),
-                  attrs: mk_doc_attr(ctx, comment),
-                  id: ast::DUMMY_NODE_ID,
-                  node: base,
-                  vis: ast::Public,
-                  span: ctx.span
-               });
+        P(ast::Item {
+            ident: ctx.ext_cx.ident_of(&rust_name),
+            attrs: mk_doc_attr(ctx, comment),
+            id: ast::DUMMY_NODE_ID,
+            node: base,
+            vis: ast::Public,
+            span: ctx.span
+        })
     }
 
-    return match *ty {
+    match *ty {
         TComp(ref ci) => {
             assert!(!ci.borrow().name.is_empty());
             vec!(mk_item(ctx, name, comment, ty))
@@ -694,12 +694,12 @@ fn cstruct_to_rs(ctx: &mut GenCtx, name: String, ci: CompInfo) -> Vec<P<ast::Ite
     let mut bitfields: u32 = 0;
 
     if ci.hide ||
-       args.iter().any(|f| match *f { TVoid => true, _ => false }) {
+       args.iter().any(|f| f == &TVoid) {
         return vec!();
     }
 
     let id = rust_type_id(ctx, name.clone());
-    let id_ty = P(mk_ty(ctx, false, vec!(id.clone())));
+    let id_ty = P(mk_ty(ctx, false, &[id.clone()]));
 
     if ci.has_vtable {
         let mut vffields = vec!();
@@ -727,7 +727,7 @@ fn cstruct_to_rs(ctx: &mut GenCtx, name: String, ci: CompInfo) -> Vec<P<ast::Ite
             let field = ast::StructField_ {
                 kind: ast::NamedField(ctx.ext_cx.ident_of("_base"), ast::Public),
                 id: ast::DUMMY_NODE_ID,
-                ty: P(mk_ty_args(ctx, false, vec!(base.clone()), vec!())),
+                ty: P(mk_ty(ctx, false, &[base.clone()])),
                 attrs: vec!(),
             };
             vffields.push(respan(ctx.span, field));
@@ -764,8 +764,8 @@ fn cstruct_to_rs(ctx: &mut GenCtx, name: String, ci: CompInfo) -> Vec<P<ast::Ite
         };
         extra.push(P(item));
 
-        if base_vftable == None {
-            let vf_type = mk_ty_args(ctx, false, vec!(vf_name), vec!());
+        if base_vftable.is_none() {
+            let vf_type = mk_ty(ctx, false, &[vf_name]);
             fields.push(respan(ctx.span, ast::StructField_ {
                 kind: ast::NamedField(ctx.ext_cx.ident_of("_vftable"), ast::Public),
                 id: ast::DUMMY_NODE_ID,
@@ -1248,7 +1248,7 @@ fn type_for_bitfield_width(ctx: &mut GenCtx, width: u32) -> ast::Ty {
     } else {
         "bool"
     };
-    mk_ty(ctx, false, vec!(input_type.to_string()))
+    mk_ty(ctx, false, &[input_type.to_owned()])
 }
 
 fn gen_bitfield_method(ctx: &mut GenCtx, bindgen_name: &String,
@@ -1365,7 +1365,7 @@ fn mk_blob_field(ctx: &GenCtx, name: &str, layout: Layout) -> Spanned<ast::Struc
     };
     let data_len = if ty_name == "u8" { layout.size } else { layout.size / layout.align };
 
-    let base_ty = mk_ty(ctx, false, vec!(ty_name.to_string()));
+    let base_ty = mk_ty(ctx, false, &[ty_name.to_owned()]);
     let data_ty = if data_len == 1 {
         P(base_ty)
     } else {
@@ -1563,8 +1563,8 @@ fn cfunc_to_rs(ctx: &mut GenCtx,
 }
 
 fn cty_to_rs(ctx: &mut GenCtx, ty: &Type, allow_bool: bool) -> ast::Ty {
-    return match ty {
-        &TVoid => mk_ty(ctx, true, vec!("libc".to_string(), "c_void".to_string())),
+    match ty {
+        &TVoid => mk_ty(ctx, true, &["libc".to_owned(), "c_void".to_owned()]),
         &TInt(i, ref layout) => match i {
             IBool => {
                 let ty_name = match layout.size {
@@ -1574,22 +1574,22 @@ fn cty_to_rs(ctx: &mut GenCtx, ty: &Type, allow_bool: bool) -> ast::Ty {
                     8 => "u64",
                     _ => "u8",
                 };
-                mk_ty(ctx, false, vec!(ty_name.to_string()))
+                mk_ty(ctx, false, &[ty_name.to_owned()])
             },
-            ISChar => mk_ty(ctx, true, vec!("libc".to_string(), "c_char".to_string())),
+            ISChar => mk_ty(ctx, true, &["libc".to_owned(), "c_char".to_owned()]),
             IInt |
             IShort |
-            ILongLong => mk_ty(ctx, false, vec!(format!("i{}", layout.size * 8))),
+            ILongLong => mk_ty(ctx, false, &[format!("i{}", layout.size * 8)]),
             IUChar |
             IUInt |
             IUShort |
-            IULongLong => mk_ty(ctx, false, vec!(format!("u{}", layout.size * 8))),
-            ILong => mk_ty(ctx, true, vec!("libc".to_string(), "c_long".to_string())),
-            IULong => mk_ty(ctx, true, vec!("libc".to_string(), "c_ulong".to_string())),
+            IULongLong => mk_ty(ctx, false, &[format!("u{}", layout.size * 8)]),
+            ILong => mk_ty(ctx, true, &["libc".to_owned(), "c_long".to_owned()]),
+            IULong => mk_ty(ctx, true, &["libc".to_owned(), "c_ulong".to_owned()]),
         },
         &TFloat(f, _) => match f {
-            FFloat => mk_ty(ctx, false, vec!("f32".to_string())),
-            FDouble => mk_ty(ctx, false, vec!("f64".to_string()))
+            FFloat => mk_ty(ctx, false, &["f32".to_owned()]),
+            FDouble => mk_ty(ctx, false, &["f64".to_owned()])
         },
         &TPtr(ref t, is_const, _is_ref, _) => {
             let id = cty_to_rs(ctx, &**t, allow_bool);
@@ -1615,20 +1615,20 @@ fn cty_to_rs(ctx: &mut GenCtx, ty: &Type, allow_bool: bool) -> ast::Ty {
         },
         &TNamed(ref ti) => {
             let id = rust_type_id(ctx, ti.borrow().name.clone());
-            mk_ty(ctx, false, vec!(id))
+            mk_ty(ctx, false, &[id])
         },
         &TComp(ref ci) => {
             let c = ci.borrow();
             let args = c.args.iter().map(|gt| {
                 P(cty_to_rs(ctx, gt, allow_bool))
             }).collect();
-            mk_ty_args(ctx, false, vec!(comp_name(c.kind, &c.name)), args)
+            mk_ty_args(ctx, false, &[comp_name(c.kind, &c.name)], args)
         },
         &TEnum(ref ei) => {
             let e = ei.borrow();
-            mk_ty(ctx, false, vec!(enum_name(&e.name)))
+            mk_ty(ctx, false, &[enum_name(&e.name)])
         }
-    };
+    }
 }
 
 fn cty_is_translatable(ty: &Type) -> bool {
@@ -1669,11 +1669,11 @@ fn cty_has_destructor(ty: &Type) -> bool {
     }
 }
 
-fn mk_ty(ctx: &GenCtx, global: bool, segments: Vec<String>) -> ast::Ty {
+fn mk_ty(ctx: &GenCtx, global: bool, segments: &[String]) -> ast::Ty {
     mk_ty_args(ctx, global, segments, vec!())
 }
 
-fn mk_ty_args(ctx: &GenCtx, global: bool, segments: Vec<String>, args: Vec<P<ast::Ty>>) -> ast::Ty {
+fn mk_ty_args(ctx: &GenCtx, global: bool, segments: &[String], args: Vec<P<ast::Ty>>) -> ast::Ty {
     let ty = ast::TyPath(
         None,
         ast::Path {

--- a/src/gen.rs
+++ b/src/gen.rs
@@ -56,25 +56,16 @@ fn rust_id(ctx: &mut GenCtx, name: String) -> (String, bool) {
 }
 
 fn rust_type_id(ctx: &mut GenCtx, name: String) -> String {
-    if "bool" == name ||
-        "uint" == name ||
-        "u8" == name ||
-        "u16" == name ||
-        "u32" == name ||
-        "f32" == name ||
-        "f64" == name ||
-        "i8" == name ||
-        "i16" == name ||
-        "i32" == name ||
-        "i64" == name ||
-        "Self" == name ||
-        "str" == name {
-        let mut s = "_".to_string();
-        s.push_str(&name);
-        s
-    } else {
-        let (n, _) = rust_id(ctx, name);
-        n
+    match &*name {
+        "bool" | "uint" | "u8" | "u16" |
+        "u32" | "f32" | "f64" | "i8" |
+        "i16" | "i32" | "i64" | "Self" |
+        "str" => {
+            let mut s = "_".to_string();
+            s.push_str(&name);
+            s
+        }
+        _ => first(rust_id(ctx, name))
     }
 }
 
@@ -134,7 +125,7 @@ fn gen_unmangle_method(ctx: &mut GenCtx,
                     unnamed += 1;
                     format!("arg{}", unnamed)
                 } else {
-                    rust_id(ctx, n.clone()).0
+                    first(rust_id(ctx, n.clone()))
                 };
                 let expr = ast::Expr {
                     id: ast::DUMMY_NODE_ID,
@@ -1179,7 +1170,7 @@ fn gen_comp_methods(ctx: &mut GenCtx, data_field: &str, data_offset: usize,
         // TODO: Implement bitfield accessors
         if f.bitfields.is_some() { return None; }
 
-        let (f_name, _) = rust_id(ctx, f.name.clone());
+        let f_name = first(rust_id(ctx, f.name.clone()));
         let ret_ty = P(cty_to_rs(ctx, &TPtr(Box::new(f.ty.clone()), false, false, Layout::zero()), true));
 
         // When the offset is zero, generate slightly prettier code.

--- a/src/gen.rs
+++ b/src/gen.rs
@@ -44,25 +44,25 @@ fn empty_generics() -> ast::Generics {
     }
 }
 
-fn rust_id(ctx: &mut GenCtx, name: String) -> (String, bool) {
-    let token = parse::token::Ident(ctx.ext_cx.ident_of(&name), parse::token::Plain);
-    if token.is_any_keyword() || "bool" == &name {
+fn rust_id(ctx: &mut GenCtx, name: &str) -> (String, bool) {
+    let token = parse::token::Ident(ctx.ext_cx.ident_of(name), parse::token::Plain);
+    if token.is_any_keyword() || "bool" == name {
         let mut s = "_".to_string();
-        s.push_str(&name);
+        s.push_str(name);
         (s, true)
     } else {
-        (name, false)
+        (name.to_owned(), false)
     }
 }
 
-fn rust_type_id(ctx: &mut GenCtx, name: String) -> String {
-    match &*name {
+fn rust_type_id(ctx: &mut GenCtx, name: &str) -> String {
+    match name {
         "bool" | "uint" | "u8" | "u16" |
         "u32" | "f32" | "f64" | "i8" |
         "i16" | "i32" | "i64" | "Self" |
         "str" => {
             let mut s = "_".to_string();
-            s.push_str(&name);
+            s.push_str(name);
             s
         }
         _ => first(rust_id(ctx, name))
@@ -76,16 +76,16 @@ fn comp_name(kind: CompKind, name: &String) -> String {
     }
 }
 
-fn struct_name(name: &String) -> String {
-    format!("{}", name)
+fn struct_name(name: &str) -> String {
+    name.to_owned()
 }
 
-fn union_name(name: &String) -> String {
-    format!("{}", name)
+fn union_name(name: &str) -> String {
+    name.to_owned()
 }
 
-fn enum_name(name: &String) -> String {
-    format!("{}", name)
+fn enum_name(name: &str) -> String {
+    name.to_owned()
 }
 
 fn gen_unmangle_method(ctx: &mut GenCtx,
@@ -125,7 +125,7 @@ fn gen_unmangle_method(ctx: &mut GenCtx,
                     unnamed += 1;
                     format!("arg{}", unnamed)
                 } else {
-                    first(rust_id(ctx, n.clone()))
+                    first(rust_id(ctx, &n))
                 };
                 let expr = ast::Expr {
                     id: ast::DUMMY_NODE_ID,
@@ -195,7 +195,7 @@ fn gen_unmangle_method(ctx: &mut GenCtx,
     count += 1;
     counts.insert(v.name.clone(), count);
 
-    let mut attrs = mk_doc_attr(ctx, v.comment.clone());
+    let mut attrs = mk_doc_attr(ctx, &v.comment);
     attrs.push(respan(ctx.span, ast::Attribute_ {
         id: mk_attr_id(),
         style: ast::AttrStyle::Outer,
@@ -689,7 +689,7 @@ fn cstruct_to_rs(ctx: &mut GenCtx, name: String, ci: CompInfo) -> Vec<P<ast::Ite
         return vec!();
     }
 
-    let id = rust_type_id(ctx, name.clone());
+    let id = rust_type_id(ctx, &name);
     let id_ty = P(mk_ty(ctx, false, &[id.clone()]));
 
     if ci.has_vtable {
@@ -832,7 +832,7 @@ fn cstruct_to_rs(ctx: &mut GenCtx, name: String, ci: CompInfo) -> Vec<P<ast::Ite
                     bitfields += 1;
                     format!("_bitfield_{}", bitfields)
                 }
-                None => rust_type_id(ctx, f.name.clone())
+                None => rust_type_id(ctx, &f.name)
             };
 
             let mut offset: u32 = 0;
@@ -868,7 +868,7 @@ fn cstruct_to_rs(ctx: &mut GenCtx, name: String, ci: CompInfo) -> Vec<P<ast::Ite
                 ),
                 id: ast::DUMMY_NODE_ID,
                 ty: f_ty,
-                attrs: mk_doc_attr(ctx, f.comment.clone())
+                attrs: mk_doc_attr(ctx, &f.comment)
             }));
             if bypass {
                 continue;
@@ -938,7 +938,7 @@ fn cstruct_to_rs(ctx: &mut GenCtx, name: String, ci: CompInfo) -> Vec<P<ast::Ite
         }
     );
 
-    let mut attrs = mk_doc_attr(ctx, ci.comment);
+    let mut attrs = mk_doc_attr(ctx, &ci.comment);
     attrs.push(mk_repr_attr(ctx, layout));
     if !has_destructor {
         attrs.push(mk_deriving_copy_attr(ctx));
@@ -1011,7 +1011,7 @@ fn opaque_to_rs(ctx: &mut GenCtx, name: String) -> P<ast::Item> {
         empty_generics()
     );
 
-    let id = rust_type_id(ctx, name);
+    let id = rust_type_id(ctx, &name);
     return P(ast::Item { ident: ctx.ext_cx.ident_of(&id),
               attrs: Vec::new(),
               id: ast::DUMMY_NODE_ID,
@@ -1049,7 +1049,7 @@ fn cunion_to_rs(ctx: &mut GenCtx, name: String, layout: Layout, members: Vec<Com
         ast::VariantData::Struct(vec![data_field], ast::DUMMY_NODE_ID),
         empty_generics()
     );
-    let union_id = rust_type_id(ctx, name.clone());
+    let union_id = rust_type_id(ctx, &name);
     let union_attrs = vec!(mk_repr_attr(ctx, layout), mk_deriving_copy_attr(ctx));
     let union_def = mk_item(ctx, union_id, def, ast::Public, union_attrs);
 
@@ -1082,7 +1082,7 @@ fn const_to_rs(ctx: &mut GenCtx, name: String, val: i64, val_ty: ast::Ty) -> P<a
         ctx.ext_cx.expr_lit(ctx.span, int_lit)
             );
 
-    let id = first(rust_id(ctx, name.clone()));
+    let id = first(rust_id(ctx, &name));
     P(ast::Item {
         ident: ctx.ext_cx.ident_of(&id[..]),
         attrs: Vec::new(),
@@ -1115,7 +1115,7 @@ fn cenum_to_rs(ctx: &mut GenCtx, name: String, comment: String, items: Vec<EnumI
 
         let variant = respan(ctx.span, ast::Variant_ {
             name: ctx.ext_cx.ident_of(&it.name),
-            attrs: mk_doc_attr(ctx, it.comment.clone()),
+            attrs: mk_doc_attr(ctx, &it.comment),
             data: ast::VariantData::Unit(ast::DUMMY_NODE_ID),
             disr_expr: Some(P(ast::Expr {
                 id: ast::DUMMY_NODE_ID,
@@ -1135,7 +1135,7 @@ fn cenum_to_rs(ctx: &mut GenCtx, name: String, comment: String, items: Vec<EnumI
         _ => "i32",
     };
 
-    let mut attrs = mk_doc_attr(ctx, comment);
+    let mut attrs = mk_doc_attr(ctx, &comment);
     attrs.push(respan(ctx.span, ast::Attribute_ {
         id: mk_attr_id(),
         style: ast::AttrStyle::Outer,
@@ -1170,7 +1170,7 @@ fn gen_comp_methods(ctx: &mut GenCtx, data_field: &str, data_offset: usize,
         // TODO: Implement bitfield accessors
         if f.bitfields.is_some() { return None; }
 
-        let f_name = first(rust_id(ctx, f.name.clone()));
+        let f_name = first(rust_id(ctx, &f.name));
         let ret_ty = P(cty_to_rs(ctx, &TPtr(Box::new(f.ty.clone()), false, false, Layout::zero()), true));
 
         // When the offset is zero, generate slightly prettier code.
@@ -1420,14 +1420,14 @@ fn mk_deriving_copy_attr(ctx: &mut GenCtx) -> ast::Attribute {
     })
 }
 
-fn mk_doc_attr(ctx: &mut GenCtx, doc: String) -> Vec<ast::Attribute> {
+fn mk_doc_attr(ctx: &mut GenCtx, doc: &str) -> Vec<ast::Attribute> {
     if doc.is_empty() {
         return vec!();
     }
 
     let attr_val = P(respan(ctx.span, ast::MetaNameValue(
         InternedString::new("doc"),
-        respan(ctx.span, ast::LitStr(intern(&doc).as_str(), ast::CookedStr))
+        respan(ctx.span, ast::LitStr(intern(doc).as_str(), ast::CookedStr))
     )));
 
     vec!(respan(ctx.span, ast::Attribute_ {
@@ -1442,7 +1442,7 @@ fn cvar_to_rs(ctx: &mut GenCtx, name: String,
                                 mangled: String,
                                 ty: &Type,
                                 is_const: bool) -> P<ast::ForeignItem> {
-    let (rust_name, was_mangled) = rust_id(ctx, name.clone());
+    let (rust_name, was_mangled) = rust_id(ctx, &name);
 
     let mut attrs = Vec::new();
     if !mangled.is_empty() {
@@ -1484,7 +1484,7 @@ fn cfuncty_to_rs(ctx: &mut GenCtx,
             unnamed += 1;
             format!("arg{}", unnamed)
         } else {
-            first(rust_id(ctx, n.clone()))
+            first(rust_id(ctx, &n))
         };
 
         // From the C90 standard (http://c0x.coding-guidelines.com/6.7.5.3.html)
@@ -1534,9 +1534,9 @@ fn cfunc_to_rs(ctx: &mut GenCtx,
         empty_generics()
     );
 
-    let (rust_name, was_mangled) = rust_id(ctx, name.clone());
+    let (rust_name, was_mangled) = rust_id(ctx, &name);
 
-    let mut attrs = mk_doc_attr(ctx, comment);
+    let mut attrs = mk_doc_attr(ctx, &comment);
     if !mangled.is_empty() {
         attrs.push(mk_link_name_attr(ctx, mangled));
     } else if was_mangled {
@@ -1605,7 +1605,7 @@ fn cty_to_rs(ctx: &mut GenCtx, ty: &Type, allow_bool: bool) -> ast::Ty {
             mk_fn_proto_ty(ctx, &decl, sig.abi)
         },
         &TNamed(ref ti) => {
-            let id = rust_type_id(ctx, ti.borrow().name.clone());
+            let id = rust_type_id(ctx, &ti.borrow().name);
             mk_ty(ctx, false, &[id])
         },
         &TComp(ref ci) => {

--- a/src/gen.rs
+++ b/src/gen.rs
@@ -37,40 +37,6 @@ impl<'r> GenCtx<'r> {
             current_id = module.parent_id;
         }
 
-        // XXX This is done because we don't actually print the root module.
-        //
-        // We include a lot of top-level "use's" instead.
-        //
-        // It might be desirable something like:
-        //
-        // ```
-        // use __randomlygeneratednameforroot::*;
-        // mod __randomlygeneratednameforroot {
-        //   pub mod b {
-        //     pub type ty = i32;
-        //   }
-        //   pub mod a {
-        //     static C: __randomlygeneratednameforroot::b::ty;
-        //   }
-        // }
-        // ```
-        //
-        // Vs:
-        //
-        // ```
-        // pub mod b {
-        //   use a;
-        //   pub type ty = i32;
-        // }
-        //
-        // pub mod a {
-        //   use b;
-        //   static C: b::ty;
-        // }
-        // ```
-        //
-        // Or even switching via flag back and forth.
-        ret.pop(); // The root isn't really here
         ret.reverse();
         ret
     }
@@ -292,50 +258,95 @@ pub fn gen_mods(links: &[(String, LinkType)], mut map: ModuleMap, span: Span) ->
         }
     });
 
-    gen_mod(&mut ctx, ROOT_MODULE_ID, links, span).items
+    if let Some(root_mod) = gen_mod(&mut ctx, ROOT_MODULE_ID, links, span) {
+        let root_export = P(ast::Item {
+            ident: ctx.ext_cx.ident_of(""),
+            attrs: vec![],
+            id: ast::DUMMY_NODE_ID,
+            node: ast::ItemUse(P(
+                Spanned {
+                    node: ast::ViewPathGlob(ast::Path {
+                        span: span.clone(),
+                        global: false,
+                        segments: vec![ast::PathSegment {
+                            identifier: root_mod.ident,
+                            parameters: ast::PathParameters::none(),
+                        }]
+                    }),
+                    span: span.clone(),
+                })),
+            vis: ast::Public,
+            span: span.clone(),
+        });
+
+        vec![root_export, root_mod]
+    } else {
+        vec![]
+    }
 }
 
 fn gen_mod(mut ctx: &mut GenCtx,
            module_id: ModuleId,
            links: &[(String, LinkType)],
-           span: Span) -> ast::Mod {
+           span: Span) -> Option<P<ast::Item>> {
 
     // XXX avoid this clone
     let module = ctx.module_map.get(&module_id).unwrap().clone();
 
-    let mut globals = gen_globals(&mut ctx, module_id, links, &module.globals);
+    // Import just the root to minimise name conflicts
+    let mut globals = if module_id != ROOT_MODULE_ID {
+        // XXX Pass this previously instead of looking it up always?
+        let root = ctx.ext_cx.ident_of(&ctx.module_map.get(&ROOT_MODULE_ID).unwrap().name);
+        vec![P(ast::Item {
+            ident: ctx.ext_cx.ident_of(""),
+            attrs: vec![],
+            id: ast::DUMMY_NODE_ID,
+            node: ast::ItemUse(P(
+                Spanned {
+                    node: ast::ViewPathSimple(root.clone(),
+                              ast::Path {
+                                  span: span.clone(),
+                                  global: false,
+                                  segments: vec![ast::PathSegment {
+                                      identifier: root,
+                                      parameters: ast::PathParameters::none(),
+                                  }]
+                              }),
+                    span: span.clone(),
+                })),
+            vis: ast::Public,
+            span: span.clone(),
+        })]
+    } else {
+        vec![]
+    };
+
+    globals.extend(gen_globals(&mut ctx, links, &module.globals).into_iter());
 
     globals.extend(module.children_ids.iter().filter_map(|id| {
-        let name = ctx.module_map.get(id).unwrap().name.clone();
-        let module = gen_mod(ctx, *id, links, span.clone());
-
-        // mod foo; represents a module in another file, not an empty module,
-        // so...
-        if !module.items.is_empty() {
-            Some(P(ast::Item {
-                ident: ctx.ext_cx.ident_of(&name),
-                attrs: vec![],
-                id: ast::DUMMY_NODE_ID,
-                node: ast::ItemMod(module),
-                vis: ast::Public,
-                span: span.clone(),
-            }))
-        } else {
-            None
-        }
+        gen_mod(ctx, *id, links, span.clone())
     }));
 
-
-    ast::Mod {
-        inner: span,
-        items: globals,
+    if !globals.is_empty() {
+        Some(P(ast::Item {
+            ident: ctx.ext_cx.ident_of(&module.name),
+            attrs: vec![],
+            id: ast::DUMMY_NODE_ID,
+            node: ast::ItemMod(ast::Mod {
+                inner: span,
+                items: globals,
+            }),
+            vis: ast::Public,
+            span: span.clone(),
+        }))
+    } else {
+        None
     }
 }
 
 
 
 fn gen_globals(mut ctx: &mut GenCtx,
-               current_module: ModuleId,
                links: &[(String, LinkType)],
                globs: &[Global]) -> Vec<P<ast::Item>> {
     let uniq_globs = tag_dup_decl(globs);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,11 +152,14 @@ impl Bindings {
 
         let span = span.unwrap_or(DUMMY_SP);
 
-        let root_module = try!(parse_headers(options, logger));
+        let module_map = try!(parse_headers(options, logger));
 
         let module = ast::Mod {
             inner: span,
-            items: gen::gen_mods(&options.links[..], root_module, span)
+            items: gen::gen_mods(&options.links[..],
+                                 module_map,
+                                 options.enable_cxx_namespaces,
+                                 span)
         };
 
         Ok(Bindings {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ use syntax::print::pprust;
 use syntax::print::pp::eof;
 use syntax::ptr::P;
 
-use types::Module;
+use types::ModuleMap;
 
 mod types;
 mod clangll;
@@ -200,7 +200,7 @@ impl Logger for DummyLogger {
     fn warn(&self, _msg: &str) { }
 }
 
-fn parse_headers(options: &BindgenOptions, logger: &Logger) -> Result<Module, ()> {
+fn parse_headers(options: &BindgenOptions, logger: &Logger) -> Result<ModuleMap, ()> {
     fn str_to_ikind(s: &str) -> Option<types::IKind> {
         match s {
             "uchar"     => Some(types::IUChar),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 #![crate_name = "bindgen"]
 #![crate_type = "dylib"]
-#![feature(convert, quote)]
+#![feature(quote)]
 
 extern crate syntex_syntax as syntax;
 extern crate libc;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -913,12 +913,11 @@ fn visit_top<'r>(cursor: &Cursor,
 }
 
 fn log_err_warn(ctx: &mut ClangParserCtx, msg: &str, is_err: bool) {
-    match is_err {
-        true => {
-            ctx.err_count += 1;
-            ctx.logger.error(msg)
-        },
-        false => ctx.logger.warn(msg)
+    if is_err {
+        ctx.err_count += 1;
+        ctx.logger.error(msg);
+    } else {
+        ctx.logger.warn(msg);
     }
 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -33,12 +33,30 @@ pub struct ClangParserOptions {
 struct ClangParserCtx<'a> {
     options: ClangParserOptions,
     name: HashMap<Cursor, Global>,
-    globals: Vec<Global>,
     builtin_defs: Vec<Cursor>,
+    module_map: ModuleMap,
+    current_module_id: ModuleId,
     logger: &'a (Logger+'a),
     err_count: i32,
-    anonymous_namespaces_found: usize,
-    namespaces: HashMap<String, ClangParserCtx<'a>>,
+    anonymous_modules_found: usize,
+}
+
+impl<'a> ClangParserCtx<'a> {
+    fn module(&self, id: &ModuleId) -> &Module {
+        self.module_map.get(id).expect("Module not found!")
+    }
+
+    fn module_mut(&mut self, id: &ModuleId) -> &mut Module {
+        self.module_map.get_mut(&id).expect("Module not found!")
+    }
+
+    fn current_module(&self) -> &Module {
+        self.module(&self.current_module_id)
+    }
+
+    fn current_module_mut(&mut self) -> &mut Module {
+        self.module_map.get_mut(&self.current_module_id).expect("Module not found!")
+    }
 }
 
 fn match_pattern(ctx: &mut ClangParserCtx, cursor: &Cursor) -> bool {
@@ -73,11 +91,11 @@ fn decl_name(ctx: &mut ClangParserCtx, cursor: &Cursor) -> Global {
         };
         let glob_decl = match cursor.kind() {
             CXCursor_StructDecl => {
-                let ci = Rc::new(RefCell::new(CompInfo::new(spelling, filename, comment, CompKind::Struct, vec!(), layout)));
+                let ci = Rc::new(RefCell::new(CompInfo::new(spelling, ctx.current_module_id, filename, comment, CompKind::Struct, vec!(), layout)));
                 GCompDecl(ci)
             }
             CXCursor_UnionDecl => {
-                let ci = Rc::new(RefCell::new(CompInfo::new(spelling, filename, comment, CompKind::Union, vec!(), layout)));
+                let ci = Rc::new(RefCell::new(CompInfo::new(spelling, ctx.current_module_id, filename, comment, CompKind::Union, vec!(), layout)));
                 GCompDecl(ci)
             }
             CXCursor_EnumDecl => {
@@ -97,11 +115,11 @@ fn decl_name(ctx: &mut ClangParserCtx, cursor: &Cursor) -> Global {
                         _ => IInt,
                     }
                 };
-                let ei = Rc::new(RefCell::new(EnumInfo::new(spelling, filename, kind, vec!(), layout)));
+                let ei = Rc::new(RefCell::new(EnumInfo::new(spelling, ctx.current_module_id, filename, kind, vec!(), layout)));
                 GEnumDecl(ei)
             }
             CXCursor_ClassTemplate => {
-                let ci = Rc::new(RefCell::new(CompInfo::new(spelling, filename, comment, CompKind::Struct, vec!(), layout)));
+                let ci = Rc::new(RefCell::new(CompInfo::new(spelling, ctx.current_module_id, filename, comment, CompKind::Struct, vec!(), layout)));
                 GCompDecl(ci)
             }
             CXCursor_ClassDecl => {
@@ -116,12 +134,12 @@ fn decl_name(ctx: &mut ClangParserCtx, cursor: &Cursor) -> Global {
                         list
                     }
                 };
-                let ci = Rc::new(RefCell::new(CompInfo::new(spelling, filename, comment, CompKind::Struct, vec!(), layout)));
+                let ci = Rc::new(RefCell::new(CompInfo::new(spelling, ctx.current_module_id, filename, comment, CompKind::Struct, vec!(), layout)));
                 ci.borrow_mut().args = args;
                 GCompDecl(ci)
             }
             CXCursor_TypedefDecl => {
-                let ti = Rc::new(RefCell::new(TypeInfo::new(spelling, TVoid, layout)));
+                let ti = Rc::new(RefCell::new(TypeInfo::new(spelling, ctx.current_module_id, TVoid, layout)));
                 GType(ti)
             }
             CXCursor_VarDecl => {
@@ -158,7 +176,7 @@ fn decl_name(ctx: &mut ClangParserCtx, cursor: &Cursor) -> Global {
 
 fn opaque_decl(ctx: &mut ClangParserCtx, decl: &Cursor) {
     let name = decl_name(ctx, decl);
-    ctx.globals.push(name);
+    ctx.current_module_mut().globals.push(name);
 }
 
 fn fwd_decl<F:FnOnce(&mut ClangParserCtx)->()>(ctx: &mut ClangParserCtx, cursor: &Cursor, f: F) {
@@ -253,6 +271,7 @@ fn mk_fn_sig(ctx: &mut ClangParserCtx, ty: &cx::Type, cursor: &Cursor) -> il::Fu
 
 fn conv_decl_ty(ctx: &mut ClangParserCtx, ty: &cx::Type, cursor: &Cursor) -> il::Type {
     let ty_decl = &ty.declaration();
+    println!("Declaration kind: {} {}", ty_decl.spelling(), kind_to_str(ty_decl.kind()));
     return match ty_decl.kind() {
         CXCursor_StructDecl |
         CXCursor_UnionDecl |
@@ -296,7 +315,7 @@ fn conv_decl_ty(ctx: &mut ClangParserCtx, ty: &cx::Type, cursor: &Cursor) -> il:
         }
         CXCursor_NoDeclFound | CXCursor_TypeAliasDecl => {
             let layout = Layout::new(ty.size(), ty.align());
-            TNamed(Rc::new(RefCell::new(TypeInfo::new(ty.spelling().replace("const ", ""), TVoid, layout))))
+            TNamed(Rc::new(RefCell::new(TypeInfo::new(ty.spelling().replace("const ", ""), ctx.current_module_id, TVoid, layout))))
         }
         _ => {
             let fail = ctx.options.fail_on_unknown_type;
@@ -312,7 +331,7 @@ fn conv_decl_ty(ctx: &mut ClangParserCtx, ty: &cx::Type, cursor: &Cursor) -> il:
 }
 
 fn conv_ty(ctx: &mut ClangParserCtx, ty: &cx::Type, cursor: &Cursor) -> il::Type {
-    debug!("conv_ty: ty=`{}` sp=`{}` loc=`{}`", type_to_str(ty.kind()), cursor.spelling(), cursor.location());
+    println!("conv_ty: ty=`{}` sp=`{}` loc=`{}`", type_to_str(ty.kind()), cursor.spelling(), cursor.location());
 
     let layout = Layout::new(ty.size(), ty.align());
     return match ty.kind() {
@@ -414,6 +433,7 @@ impl Annotations {
 fn visit_composite(cursor: &Cursor, parent: &Cursor,
                    ctx: &mut ClangParserCtx,
                    ci: &mut CompInfo) -> Enum_CXVisitorResult {
+    println!("visit_composite: {} {} {}", kind_to_str(cursor.kind()), cursor.spelling(), cursor.location());
 
     fn is_bitfield_continuation(field: &il::FieldInfo, ty: &il::Type, width: u32) -> bool {
         match (&field.bitfields, ty) {
@@ -542,7 +562,7 @@ fn visit_composite(cursor: &Cursor, parent: &Cursor,
         CXCursor_TemplateTypeParameter => {
             let ty = conv_ty(ctx, &cursor.cur_type(), cursor);
             let layout = Layout::new(ty.size(), ty.align());
-            ci.args.push(TNamed(Rc::new(RefCell::new(TypeInfo::new(cursor.spelling(), TVoid, layout)))));
+            ci.args.push(TNamed(Rc::new(RefCell::new(TypeInfo::new(cursor.spelling(), ctx.current_module_id, TVoid, layout)))));
         }
         CXCursor_EnumDecl => {
             let anno = Annotations::new(cursor);
@@ -650,7 +670,7 @@ fn visit_composite(cursor: &Cursor, parent: &Cursor,
                     sig.args.insert(0, ("this".to_string(),TPtr(Box::new(TVoid), cursor.cur_type().is_const(), false, Layout::zero())));
                 } else {
                     sig.args.insert(0, ("this".to_string(),
-                                        TPtr(Box::new(TNamed(Rc::new(RefCell::new(TypeInfo::new(ci.name.clone(), TVoid, Layout::zero()))))), cursor.cur_type().is_const(), false, Layout::zero())));
+                                        TPtr(Box::new(TNamed(Rc::new(RefCell::new(TypeInfo::new(ci.name.clone(), ctx.current_module_id, TVoid, Layout::zero()))))), cursor.cur_type().is_const(), false, Layout::zero())));
                 }
             }
 
@@ -734,6 +754,7 @@ fn visit_literal(cursor: &Cursor, unit: &TranslationUnit) -> Option<i64> {
 fn visit_top<'r>(cursor: &Cursor,
                  mut ctx: &mut ClangParserCtx,
                  unit: &TranslationUnit) -> Enum_CXVisitorResult {
+    println!("visit_top: {}", cursor.location());
     if !match_pattern(ctx, cursor) {
         return CXChildVisit_Continue;
     }
@@ -757,7 +778,7 @@ fn visit_top<'r>(cursor: &Cursor,
                 if anno.hide {
                     ci.borrow_mut().hide = true;
                 }
-                ctx_.globals.push(GComp(ci));
+                ctx_.current_module_mut().globals.push(GComp(ci));
             });
             return CXChildVisit_Continue;
         }
@@ -770,7 +791,7 @@ fn visit_top<'r>(cursor: &Cursor,
                     let mut ei_ = ei.borrow_mut();
                     visit_enum(c, &mut ei_.items)
                 });
-                ctx_.globals.push(GEnum(ei));
+                ctx_.current_module_mut().globals.push(GEnum(ei));
             });
             return CXChildVisit_Continue;
         }
@@ -796,7 +817,7 @@ fn visit_top<'r>(cursor: &Cursor,
             let mut vi = vi.borrow_mut();
 
             vi.ty = TFuncPtr(mk_fn_sig(ctx, &cursor.cur_type(), cursor));
-            ctx.globals.push(func);
+            ctx.current_module_mut().globals.push(func);
 
             return CXChildVisit_Continue;
         }
@@ -820,7 +841,7 @@ fn visit_top<'r>(cursor: &Cursor,
                 vi.val = visit_literal(c, unit);
                 CXChildVisit_Continue
             });
-            ctx.globals.push(var);
+            ctx.current_module_mut().globals.push(var);
 
             return CXChildVisit_Continue;
         }
@@ -840,7 +861,7 @@ fn visit_top<'r>(cursor: &Cursor,
             let mut ti = ti.borrow_mut();
             ti.ty = ty.clone();
             ti.comment = cursor.raw_comment();
-            ctx.globals.push(typedef);
+            ctx.current_module_mut().globals.push(typedef);
 
             opaque_ty(ctx, &under_ty);
 
@@ -867,24 +888,33 @@ fn visit_top<'r>(cursor: &Cursor,
                     }
                 }
             }.unwrap_or_else(|| {
-                ctx.anonymous_namespaces_found += 1;
-                format!("__anonymous{}", ctx.anonymous_namespaces_found)
+                ctx.anonymous_modules_found += 1;
+                format!("__anonymous{}", ctx.anonymous_modules_found)
             });
 
-            let mut ns_ctx = ctx.namespaces.entry(namespace_name).or_insert(
-                ClangParserCtx {
-                    options: ctx.options.clone(),
-                    name: HashMap::new(),
-                    builtin_defs: vec!(),
-                    globals: vec!(),
-                    logger: ctx.logger,
-                    err_count: 0,
-                    anonymous_namespaces_found: 0,
-                    namespaces: HashMap::new(),
-                }
-            );
+            // Find an existing namespace children of the current one
+            let mod_id = ctx.current_module()
+                            .children_ids.iter()
+                            .find(|id| ctx.module_map.get(id).unwrap().name == namespace_name)
+                            .map(|id| *id);
 
-            cursor.visit(|cur, _: &Cursor| visit_top(cur, &mut ns_ctx, &unit));
+            let mod_id = match mod_id {
+                Some(id) => id,
+                None => {
+                    println!("Creating namespace {}", namespace_name);
+                    let parent_id = ctx.current_module_id;
+                    let id = ModuleId::next();
+                    ctx.module_map.get_mut(&parent_id).unwrap().children_ids.push(id);
+                    ctx.module_map.insert(id, Module::new(namespace_name, Some(parent_id)));
+                    id
+                }
+            };
+
+            let previous_id = ctx.current_module_id;
+
+            ctx.current_module_id = mod_id;
+            cursor.visit(|cur, _: &Cursor| visit_top(cur, &mut ctx, &unit));
+            ctx.current_module_id = previous_id;
 
             return CXChildVisit_Continue;
         }
@@ -904,7 +934,7 @@ fn visit_top<'r>(cursor: &Cursor,
             };
             vi.is_const = true;
             vi.val = val;
-            ctx.globals.push(var);
+            ctx.current_module_mut().globals.push(var);
 
             return CXChildVisit_Continue;
         }
@@ -921,17 +951,19 @@ fn log_err_warn(ctx: &mut ClangParserCtx, msg: &str, is_err: bool) {
     }
 }
 
-pub fn parse(options: ClangParserOptions, logger: &Logger) -> Result<Module, ()> {
+pub fn parse(options: ClangParserOptions, logger: &Logger) -> Result<ModuleMap, ()> {
     let mut ctx = ClangParserCtx {
         options: options,
         name: HashMap::new(),
         builtin_defs: vec!(),
-        globals: vec!(),
+        module_map: ModuleMap::new(),
+        current_module_id: ROOT_MODULE_ID,
         logger: logger,
         err_count: 0,
-        anonymous_namespaces_found: 0,
-        namespaces: HashMap::new(),
+        anonymous_modules_found: 0,
     };
+
+    ctx.module_map.insert(ROOT_MODULE_ID, Module::new("root".to_owned(), None));
 
     let ix = cx::Index::create(false, true);
     if ix.is_null() {
@@ -976,19 +1008,5 @@ pub fn parse(options: ClangParserOptions, logger: &Logger) -> Result<Module, ()>
         return Err(())
     }
 
-    let mut root = Module::new();
-
-    fn add_submodules<'a>(module: &mut Module,
-                          mut ctx: ClangParserCtx<'a>) {
-        mem::replace(module.globals(), ctx.globals);
-        for (name, ns) in ctx.namespaces.drain() {
-            let mut new = Module::new();
-            add_submodules(&mut new, ns);
-            module.add_submodule(name, new);
-        }
-    }
-
-    add_submodules(&mut root, ctx);
-
-    Ok(root)
+    Ok(ctx.module_map)
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -5,7 +5,6 @@ use std::cell::RefCell;
 use std::ops::Deref;
 use std::rc::Rc;
 use std::path::Path;
-use std::mem;
 
 use syntax::abi;
 
@@ -44,10 +43,6 @@ struct ClangParserCtx<'a> {
 impl<'a> ClangParserCtx<'a> {
     fn module(&self, id: &ModuleId) -> &Module {
         self.module_map.get(id).expect("Module not found!")
-    }
-
-    fn module_mut(&mut self, id: &ModuleId) -> &mut Module {
-        self.module_map.get_mut(&id).expect("Module not found!")
     }
 
     fn current_module(&self) -> &Module {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -271,7 +271,6 @@ fn mk_fn_sig(ctx: &mut ClangParserCtx, ty: &cx::Type, cursor: &Cursor) -> il::Fu
 
 fn conv_decl_ty(ctx: &mut ClangParserCtx, ty: &cx::Type, cursor: &Cursor) -> il::Type {
     let ty_decl = &ty.declaration();
-    println!("Declaration kind: {} {}", ty_decl.spelling(), kind_to_str(ty_decl.kind()));
     return match ty_decl.kind() {
         CXCursor_StructDecl |
         CXCursor_UnionDecl |
@@ -331,8 +330,6 @@ fn conv_decl_ty(ctx: &mut ClangParserCtx, ty: &cx::Type, cursor: &Cursor) -> il:
 }
 
 fn conv_ty(ctx: &mut ClangParserCtx, ty: &cx::Type, cursor: &Cursor) -> il::Type {
-    println!("conv_ty: ty=`{}` sp=`{}` loc=`{}`", type_to_str(ty.kind()), cursor.spelling(), cursor.location());
-
     let layout = Layout::new(ty.size(), ty.align());
     return match ty.kind() {
         CXType_Void | CXType_Invalid => TVoid,
@@ -433,7 +430,6 @@ impl Annotations {
 fn visit_composite(cursor: &Cursor, parent: &Cursor,
                    ctx: &mut ClangParserCtx,
                    ci: &mut CompInfo) -> Enum_CXVisitorResult {
-    println!("visit_composite: {} {} {}", kind_to_str(cursor.kind()), cursor.spelling(), cursor.location());
 
     fn is_bitfield_continuation(field: &il::FieldInfo, ty: &il::Type, width: u32) -> bool {
         match (&field.bitfields, ty) {
@@ -754,7 +750,6 @@ fn visit_literal(cursor: &Cursor, unit: &TranslationUnit) -> Option<i64> {
 fn visit_top<'r>(cursor: &Cursor,
                  mut ctx: &mut ClangParserCtx,
                  unit: &TranslationUnit) -> Enum_CXVisitorResult {
-    println!("visit_top: {}", cursor.location());
     if !match_pattern(ctx, cursor) {
         return CXChildVisit_Continue;
     }
@@ -901,7 +896,6 @@ fn visit_top<'r>(cursor: &Cursor,
             let mod_id = match mod_id {
                 Some(id) => id,
                 None => {
-                    println!("Creating namespace {}", namespace_name);
                     let parent_id = ctx.current_module_id;
                     let id = ModuleId::next();
                     ctx.module_map.get_mut(&parent_id).unwrap().children_ids.push(id);

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -142,7 +142,10 @@ fn decl_name(ctx: &mut ClangParserCtx, cursor: &Cursor) -> Global {
                         } else {
                             None
                         }
-                    }).expect("Template class wasn't declared when parsing specialisation!")
+                    }).unwrap_or_else(|| {
+                        ctx.logger.warn("Template class wasn't declared when parsing specialisation!");
+                        ctx.current_module_id
+                    })
                 };
 
                 let ci = Rc::new(RefCell::new(CompInfo::new(spelling, module_id, filename, comment, CompKind::Struct, vec!(), layout)));

--- a/tests/headers/namespace.h
+++ b/tests/headers/namespace.h
@@ -30,12 +30,14 @@ class C<int>;
 
 
 namespace w {
+    typedef unsigned int whatever_int_t;
 
     template<typename T>
     class D {
         C<T> m_c;
-        void wat();
     };
+
+    whatever_int_t heh(); // this should return w::whatever_int_t, and not whatever::whatever_int_t
 
     C<int> foo();
 

--- a/tests/headers/namespace.h
+++ b/tests/headers/namespace.h
@@ -12,9 +12,30 @@ namespace {
     namespace empty {}
 
     void foo();
-
-    class A {
+    struct A {
         whatever::whatever_int_t b;
+    public:
+        int lets_hope_this_works();
     };
 }
 
+template<typename T>
+class C: public A {
+    T m_c;
+};
+
+
+template<>
+class C<int>;
+
+
+namespace w {
+
+    template<typename T>
+    class D {
+        C<T> m_c;
+        void wat();
+    };
+
+    C<int> foo();
+}

--- a/tests/headers/namespace.h
+++ b/tests/headers/namespace.h
@@ -38,4 +38,6 @@ namespace w {
     };
 
     C<int> foo();
+
+    C<float> barr(); // <- This is the problematic one
 }


### PR DESCRIPTION
I couldn't sleep so... I went with it.

Wasn't easy, there were a few corner cases, but it worked out pretty well.

To see why we're doing the things like we're, please read https://github.com/bholley/rust-bindgen/commit/e90066a5bebe308bd28c46b795c398eca3de083b (I later changed my mind and removed it).

This keeps the namespace work behind a flag, just in case there's some corner case it still can't handle. It seems pretty stable though.

r? @bholley 
